### PR TITLE
try catch on inconsistency from action rg 1200 on software version 2.1.2

### DIFF
--- a/lib/cwmp.ts
+++ b/lib/cwmp.ts
@@ -840,10 +840,23 @@ async function endSession(sessionContext: SessionContext): Promise<void> {
 
   await Promise.all(promises);
 
-  await cache.releaseLock(
-    `cwmp_session_${sessionContext.deviceId}`,
-    sessionContext.sessionId
-  );
+  try {
+    await cache.releaseLock(
+      `cwmp_session_${sessionContext.deviceId}`,
+      sessionContext.sessionId
+    );
+  } catch (e) {
+    if (sessionContext.deviceId === 'C83A35-ACtion%20RG1200-d83214881173') {
+      logger.accessInfo({
+        sessionContext: sessionContext,
+        message: 'We found you messing up once again, Action RG1200 on SoftwareVersion=2.1.2...',
+      });
+    } else {
+      // Rethrow
+      throw e;
+    }
+  }
+
   if (sessionContext.new) {
     metricsExporter.registeredDevice.inc();
     logger.accessInfo({


### PR DESCRIPTION
Informs por segundo no flashman, antes e depois desse fix, num cliente que tinha esse Action RG 1200 na base:
![image](https://github.com/anlix-io/genieacs/assets/12648211/bde308ba-773a-4b5b-8661-14f7730a3d7d)

O caos de antes era por causa do crash constante no cwmp
